### PR TITLE
fix: add cookie name to proxy

### DIFF
--- a/deployment/kubernetes/client-registration-api.yaml
+++ b/deployment/kubernetes/client-registration-api.yaml
@@ -110,6 +110,8 @@ spec:
               value: "true"
             - name: OAUTH2_PROXY_FORCE_JSON_ERRORS
               value: "true"
+            - name: OAUTH2_PROXY_COOKIE_NAME
+              value: "__Secure-openepi_user"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Adds cookie name to Oauth2 proxy. This ensures the name is the same everywhere.